### PR TITLE
fix: report directory events and respect request event types

### DIFF
--- a/chokidar/chokidar-cli/index.js
+++ b/chokidar/chokidar-cli/index.js
@@ -8,10 +8,10 @@ const chokidar = require('chokidar');
 /** @type {Record<ChokidarCli.ChokidarEventType, ChokidarCli.LspEventType | null>} */
 const CHOKIDAR_EVENT_TYPE_TO_LSP = {
     add: 'create',
-    addDir: null,
+    addDir: 'create',
     change: 'change',
     unlink: 'delete',
-    unlinkDir: null,
+    unlinkDir: 'delete',
 };
 
 /** @type {Partial<ChokidarCli.RegisterWatcherOptions>} */
@@ -117,6 +117,10 @@ function registerWatcher(opts) {
             if (opts.debug) {
                 console.error(`Unsupported event type "${event}".`);
             }
+            return;
+        }
+
+        if (!opts.events.includes(lspEvent)) {
             return;
         }
 


### PR DESCRIPTION
Discovered two issues:
1. The events for directory creation/deletion were not reported. Spec says that despite the name those should be reported
> note although the name suggest that only file events are sent it is about file system events which include folders as well
> https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles
2. Always all 3 event types (create/change/delete) were reported even if LSP requested only a subset of those. Add proper filtering.